### PR TITLE
Set framework to static link

### DIFF
--- a/ios/amap_location_flutter_plugin.podspec
+++ b/ios/amap_location_flutter_plugin.podspec
@@ -16,6 +16,7 @@ AMapLocation flutter plugin
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
 
+  s.static_framework = true
   s.ios.deployment_target = '8.0'
   s.dependency 'AMapLocation','~>2.6.7'
 end


### PR DESCRIPTION
When use this plugin in project with **use_frameworks!** in ios/Podfile, building process will end up with error like below:
``` shell
the 'pods-runner' target has transitive dependencies that include statically linked binaries: (xxxx/ios/Pods/AMapLocation/AMapLocationKit.framework)
```

To set framework to static link will fix this problem.

reference: [CocoaPods description](https://blog.cocoapods.org/CocoaPods-1.4.0/).